### PR TITLE
use basix wrapper not ufl directly

### DIFF
--- a/notebooks.ipynb
+++ b/notebooks.ipynb
@@ -105,8 +105,9 @@
    "outputs": [],
    "source": [
     "import ufl\n",
-    "ufl_tri = ufl.Mesh(ufl.VectorElement(\"Lagrange\", ufl.triangle, 1))\n",
-    "ufl_quad = ufl.Mesh(ufl.VectorElement(\"Lagrange\", ufl.quadrilateral, 1))"
+    "from basix.ufl_wrapper import create_vector_element\n",
+    "ufl_tri = ufl.Mesh(create_vector_element(\"Lagrange\", \"triangle\", 1))\n",
+    "ufl_quad = ufl.Mesh(create_vector_element(\"Lagrange\", \"quadrilateral\", 1))"
    ]
   },
   {


### PR DESCRIPTION
I guess we might want to hold off on merging this until the changes to the naming in the ufl wrapper (https://github.com/FEniCS/basix/pull/655) are merged.

These changes will rename `basix.ufl_wrapper` to `basix.ufl` and `create_vector_element` to `vector_element`.